### PR TITLE
Revert "gcc version 9.5.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:9.5.0
+FROM gcc:latest
 
 LABEL maintainer="Mark Barzali"
 LABEL maintainer.email="re.markofdark@gmail.com"


### PR DESCRIPTION
This reverts commit 4c6dc479d64e2e834d5516232abcfcc7031a7912.